### PR TITLE
Support for complex nested objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'singer-python==5.9.0',
         'backoff==1.8.0',
         'requests==2.22.0',
+        'ijson==3.0.4',
     ],
     extras_require={
         'dev': [

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -9,7 +9,7 @@ def stream_report(report_url, user, password):
                 context = ElementTree.iterparse(stream, events=("start", "end"))
                 for event, elem in context:
                     yield (event, elem)
-            except ElementTree.ParseError as e:
+            except ElementTree.ParseError:
                 raise Exception("Report URL {} does not parse as XML. Please ensure the integration is configured with the correct URL".format(report_url))
 
 def download_xsd(report_url, user, password):

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -28,7 +28,7 @@ def stream_report(report_url, user, password):
 
 def download_xsd(report_url, user, password):
     if '?' in report_url:
-        xsds_url = report_url.split('?')[0] + '?xsd'
+        xsds_url = report_url.split('?')[0] + '?xsds'
     else:
         xsds_url = report_url + '?xsds'
     response = requests.get(xsds_url, auth=(user, password))

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -11,7 +11,7 @@ def stream_report(report_url, user, password):
     if len(url_breakdown) == 1:
         params = []
     else:
-        params = [x for x in url_breakdown[1].split('&') if not x.startswith('format')]
+        params = [x for x in url_breakdown[1].split('&') if not x.startswith('format=')]
 
     # Add the format param
     params.append('format=json')

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -22,7 +22,7 @@ def stream_report(report_url, user, password):
     # Get the data
     with requests.get(corrected_url, auth=(user, password), stream=True) as resp:
         resp.raise_for_status()
-        report = resp.json() # TODO Check that this is streaming. I worry that calling json() pulls down the whole file
+        report = resp.json() # TODO Check that this is streaming. I don't think it is
         for record in report['Report_Entry']:
             yield record
 

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -26,10 +26,9 @@ def _element_to_schema(element):
             'format': 'date-time'
         }
     elif elem_type == 'decimal':
-        #TODO What else do we need for decimal types?
+        # TODO Update to the singer.decimal format when that is available
         schema = {
             'type': ['number'],
-            'format': 'singer-decimal'
         }
     else:
         schema = {'type': [elem_type]}

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -12,7 +12,7 @@ def _element_to_schema(element):
     elem_type = element.attrib['type'].split(':')[1]
     is_nullable = element.attrib.get('minOccurs') == '0'
 
-    max_occurs = elem.attrib.get("maxOccurs")
+    max_occurs = element.attrib.get("maxOccurs")
     if max_occurs not in (None, "unbounded"):
         raise Exception("Found unexpected value for maxOccurs attribute.")
 
@@ -90,7 +90,7 @@ def generate_schema_for_report(xsd):
 
             is_list = max_occurs == 'unbounded'
 
-            if is_list: 
+            if is_list:
                 elem_schema = {'type': 'array',
                                'items': complex_type_mapping[elem_type]}
             else:

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -34,7 +34,6 @@ def _element_to_schema(element):
         schema['type'].append('null')
 
     if is_list:
-        LOGGER.info("FOUND A LIST!: %s", element.attrib['name'])
         schema = {
             'type': 'array',
             'items': schema

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -86,7 +86,7 @@ def generate_schema_for_report(xsd):
 
             max_occurs = elem.attrib.get("maxOccurs")
             if max_occurs not in (None, "unbounded"):
-                raise Exception("Found unexpected value for maxOccurs attribute.")
+                raise Exception("Found unexpected value for maxOccurs attribute: '{}'".format(maxOccurs))
 
             is_list = max_occurs == 'unbounded'
 

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -22,25 +22,56 @@ def _type_to_schema(elem_type):
     else:
         return {'type': [elem_type, 'null']}
 
+# TODO: Test this logic
+def parse_complex_type(complex_type_selectors, xsd_schema_et, ns):
+    complex_type_mapping = {}
+    for selector in complex_type_selectors:
+        complex_type = xsd_schema_et.find(selector, ns)
+        name = complex_type.attrib['name']
+        complex_type_mapping[name] = {'type': 'object', 'properties': {}}
+        for element in complex_type.findall('.//xsd:element', ns):
+            elem_name = element.attrib['name']
+            elem_type = element.attrib['type'].split(':')[1]
+            schema_type = _type_to_schema(elem_type)
+            complex_type_mapping[name]['properties'][elem_name] = {
+                **schema_type
+            }
+
+    return complex_type_mapping
+
+# TODO: refactor this so we can test it.
 def get_schema_for_report(report, username, password):
     xsd_schema = download_xsd(report['report_url'], username, password)
     xsd_schema_et = ElementTree.fromstring(xsd_schema)
+    ns = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
 
     schema = {'type': 'object', 'properties': {}}
 
+    # The report structure is defined by two complexType elements
+    report_structure_elem_names = {'Report_EntryType', 'Report_DataType'}
+    all_complex_type_names = {e.attrib['name'] for e in xsd_schema_et.findall("./xsd:complexType", ns)}
 
-    for base_elem in xsd_schema_et:
-        if base_elem.attrib['name'] == 'Report_EntryType':
-            for sequence in base_elem:
-                for elem in sequence:
-                    elem_type = elem.attrib['type'].split(':')[1]
-                    elem_name = elem.attrib['name']
+    # The set difference results in complexType elements that are used in Report_EntryType to define nested objects
+    complex_types = all_complex_type_names - report_structure_elem_names
 
-                    schema_type = _type_to_schema(elem_type)
+    # Compute JSON Schemas for other complexType elements which will become nested objects
+    complex_type_mapping = parse_complex_type(["./xsd:complexType[@name='{}']".format(i) for i in complex_types], xsd_schema_et, ns)
 
-                    schema['properties'][elem_name] = {
-                        **schema_type
-                    }
+    # Iterate the 'element' elements nested under the sequence element of the Report definition's complexType
+    for elem in xsd_schema_et.findall("./xsd:complexType[@name='Report_EntryType']/xsd:sequence/xsd:element", ns):
+        elem_type = elem.attrib['type'].split(':')[1]
+        elem_name = elem.attrib['name']
+
+        # When elem's type attribute is a type defined as its own complexType - a nested object
+        if elem_type in complex_type_mapping:
+            schema['properties'][elem_name] = complex_type_mapping[elem_type]
+            continue
+
+        schema_type = _type_to_schema(elem_type)
+
+        schema['properties'][elem_name] = {
+            **schema_type
+        }
     return schema
 
 def discover_streams(config):

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -14,7 +14,7 @@ def _element_to_schema(element):
 
     max_occurs = element.attrib.get("maxOccurs")
     if max_occurs not in (None, "unbounded"):
-        raise Exception("Found unexpected value for maxOccurs attribute.")
+        raise Exception("Found unexpected value for maxOccurs attribute: '{}'".format(max_occurs))
 
     is_list = max_occurs == 'unbounded'
 
@@ -85,7 +85,7 @@ def generate_schema_for_report(xsd):
 
             max_occurs = elem.attrib.get("maxOccurs")
             if max_occurs not in (None, "unbounded"):
-                raise Exception("Found unexpected value for maxOccurs attribute: '{}'".format(maxOccurs))
+                raise Exception("Found unexpected value for maxOccurs attribute: '{}'".format(max_occurs))
 
             is_list = max_occurs == 'unbounded'
 

--- a/tap_workday_raas/sync.py
+++ b/tap_workday_raas/sync.py
@@ -22,29 +22,13 @@ def sync_report(report, stream, config):
     singer.write_version(stream.tap_stream_id, stream_version)
 
     with Transformer() as transformer:
-        for event, elem in stream_report(report_url, username, password):
-            elem_name = elem.tag.split('}')[1]
-            if elem_name == 'Report_Data':
-                continue
-            if elem_name == 'Report_Entry':
-                if event == 'end':
-                    to_write = transformer.transform(record, stream.schema.to_dict(), metadata.to_map(stream.metadata))
-                    to_write['_sdc_extracted_at'] = extraction_time
-                    record_message = singer.RecordMessage(stream.tap_stream_id,
-                                                          to_write,
-                                                          version=stream_version)
-                    singer.write_message(record_message)
-                    record_count += 1
-                    record = {}
-            elif event == 'start':
-                #TODO Check if there are multiple of the element. If yes then parse them as an array
-
-                # If the streaming element has children, its a complexType
-                if elem.getchildren():
-                    record[elem_name] = {}
-                    for child in elem.getchildren():
-                        record[elem_name][child.tag.split('}')[1]] = child.text
-                else:
-                    record[elem_name] = elem.text
+        for record in stream_report(report_url, username, password):
+            to_write = transformer.transform(record, stream.schema.to_dict(), metadata.to_map(stream.metadata))
+            to_write['_sdc_extracted_at'] = extraction_time
+            record_message = singer.RecordMessage(stream.tap_stream_id,
+                                                  to_write,
+                                                  version=stream_version)
+            singer.write_message(record_message)
+            record_count += 1
 
     return record_count

--- a/tap_workday_raas/sync.py
+++ b/tap_workday_raas/sync.py
@@ -37,6 +37,8 @@ def sync_report(report, stream, config):
                     record_count += 1
                     record = {}
             elif event == 'start':
+                #TODO Check if there are multiple of the element. If yes then parse them as an array
+
                 # If the streaming element has children, its a complexType
                 if elem.getchildren():
                     record[elem_name] = {}

--- a/tap_workday_raas/sync.py
+++ b/tap_workday_raas/sync.py
@@ -37,7 +37,12 @@ def sync_report(report, stream, config):
                     record_count += 1
                     record = {}
             elif event == 'start':
-                record[elem_name] = elem.text
-
+                # If the streaming element has children, its a complexType
+                if elem.getchildren():
+                    record[elem_name] = {}
+                    for child in elem.getchildren():
+                        record[elem_name][child.tag.split('}')[1]] = child.text
+                else:
+                    record[elem_name] = elem.text
 
     return record_count

--- a/tests/test_workday_raas_sync.py
+++ b/tests/test_workday_raas_sync.py
@@ -35,7 +35,7 @@ class WorkdayRaasSync(unittest.TestCase):
 
     def get_properties(self):
         return {
-            'start_date' : '2015-03-15 00:00:00',
+            'start_date' : '2015-03-15T00:00:00Z',
             'username': os.getenv('TAP_WORKDAY_RAAS_USERNAME'),
             'reports': '[{\"report_url\":\"https://wd2-impl-services1.workday.com/ccx/service/customreport2/talend_dpt1/lmcneil/Stitch_Test_Report?Roles%21WID=8d9435a66f9a431ab5377671801b9841\",\"report_name\":\"stitch_test_report\"}]'
         }

--- a/tests/test_workday_raas_sync.py
+++ b/tests/test_workday_raas_sync.py
@@ -37,7 +37,7 @@ class WorkdayRaasSync(unittest.TestCase):
         return {
             'start_date' : '2015-03-15 00:00:00',
             'username': os.getenv('TAP_WORKDAY_RAAS_USERNAME'),
-            'reports': '[{\"report_url\":\"https://i-0705abe4c72d24e6a.workdaysuv.com/ccx/service/customreport2/gms/lmcneil/stitch_test_report?End_Date=2020-02-19-08:00&Start_Date=2020-02-12-08:00\",\"report_name\":\"stitch_test_report\"}]'
+            'reports': '[{\"report_url\":\"https://wd2-impl-services1.workday.com/ccx/service/customreport2/talend_dpt1/lmcneil/Stitch_Test_Report?Roles%21WID=8d9435a66f9a431ab5377671801b9841\",\"report_name\":\"stitch_test_report\"}]'
         }
 
     def test_run(self):

--- a/tests/test_workday_raas_sync.py
+++ b/tests/test_workday_raas_sync.py
@@ -5,6 +5,8 @@ import os
 import unittest
 from functools import reduce
 
+import json
+
 class WorkdayRaasSync(unittest.TestCase):
     def setUp(self):
         missing_envs = [x for x in [os.getenv('TAP_WORKDAY_RAAS_USERNAME'),
@@ -37,7 +39,8 @@ class WorkdayRaasSync(unittest.TestCase):
         return {
             'start_date' : '2015-03-15T00:00:00Z',
             'username': os.getenv('TAP_WORKDAY_RAAS_USERNAME'),
-            'reports': '[{\"report_url\":\"https://wd2-impl-services1.workday.com/ccx/service/customreport2/talend_dpt1/lmcneil/Stitch_Test_Report?Roles%21WID=8d9435a66f9a431ab5377671801b9841\",\"report_name\":\"stitch_test_report\"}]'
+            'reports': json.dumps([{'report_url': 'https://wd2-impl-services1.workday.com/ccx/service/customreport2/talend_dpt1/lmcneil/Stitch_Testing_2?format=simplexml',
+                                    'report_name': 'stitch_test_report'}]),
         }
 
     def test_run(self):

--- a/tests/test_workday_raas_sync.py
+++ b/tests/test_workday_raas_sync.py
@@ -39,7 +39,7 @@ class WorkdayRaasSync(unittest.TestCase):
         return {
             'start_date' : '2015-03-15T00:00:00Z',
             'username': os.getenv('TAP_WORKDAY_RAAS_USERNAME'),
-            'reports': json.dumps([{'report_url': 'https://wd2-impl-services1.workday.com/ccx/service/customreport2/talend_dpt1/lmcneil/Stitch_Testing_2?format=simplexml',
+            'reports': json.dumps([{'report_url': 'https://wd2-impl-services1.workday.com/ccx/service/customreport2/talend_dpt1/lmcneil/Stitch_Testing_2',
                                     'report_name': 'stitch_test_report'}]),
         }
 

--- a/tests/unittests/discovery_tests.py
+++ b/tests/unittests/discovery_tests.py
@@ -1,0 +1,59 @@
+import unittest
+from tap_workday_raas import discover
+
+
+xsd = """<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wd="urn:com.workday.report/Stitch_Testing_2" xmlns:nyw="urn:com.netyourwork/aod" elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday.report/Stitch_Testing_2">
+    <xsd:element name="Report_Data" type="wd:Report_DataType"/>
+    <xsd:simpleType name="RichText">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:complexType name="Candidate_Details_groupType">
+        <xsd:sequence>
+            <xsd:element name="Employee" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Willing_To_Travel" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Potential" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Report_EntryType">
+        <xsd:sequence>
+            <xsd:element name="Default_Job_Title" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Average_Pay_-_Amount" type="xsd:decimal" minOccurs="0"/>
+            <xsd:element name="job_profile_id" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Languages" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Default_Assessment_Tests" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Business_Unit_or_Business_Unit_Hierarchy_Container" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Candidate_Details_group" type="wd:Candidate_Details_groupType" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Report_DataType">
+        <xsd:sequence>
+            <xsd:element name="Report_Entry" type="wd:Report_EntryType" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>
+"""
+
+class DiscoveryTest(unittest.TestCase):
+
+    def test_generate_schema_for_report(self):
+
+        expected = {'properties':
+                    {'Average_Pay_-_Amount': {'format': 'decimal',
+                                              'type': ['number', 'null']},
+                     'Business_Unit_or_Business_Unit_Hierarchy_Container': {'type': ['string', 'null']},
+                     'Candidate_Details_group': {'items':
+                                                 {'properties': {'Employee': {'type': ['string', 'null']},
+                                                                 'Potential': {'type': ['string', 'null']},
+                                                                 'Willing_To_Travel': {'type': ['string', 'null']}},
+                                                  'type': 'object'},
+                                                 'type': 'array'},
+                     'Default_Assessment_Tests': {'type': ['string', 'null']},
+                     'Default_Job_Title': {'type': ['string', 'null']},
+                     'Languages': {'type': ['string', 'null']},
+                     'job_profile_id': {'type': ['string', 'null']}},
+                    'type': 'object'}
+
+        actual = discover.generate_schema_for_report(xsd)
+        
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
# Description of change
Adding support for custom complex objects.

After looking at the output generated from a more complex report it has led us to the conclusion that using a format of json and then using the xsds for schema generation will be ideal. Using `format=json` makes syncing the data easy and the xsds includes sufficient type information for the JSON to allow the transformer to properly cast decimals.

Part of this change includes manipulating the URL to force it to have a `format=json` query parameter. This will allow the tap to work without needing our customers to update their config.

# Manual QA steps
 - Created a new report with complex types and tested syncing json format
 
# Risks
 - There is a potential for column splitting and I can find no guarantee that the JSON format is available for all reports. We might get through this only to find that our customers don't have JSON enabled for some reason.
 - It is unclear whether the current implementation streams the JSON or if it downloads it all at the start. It's also unclear whether worrying about streaming the report is pre-emptive optimization and would not cause issues even if it was downloaded wholesale.
 
# Rollback steps
 - revert this branch
