### PR TITLE
Decode chunk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "singer-python==5.9.0",
         "backoff==1.8.0",
         "requests==2.22.0",
-        "ijson==3.0.4",
+        "ijson==3.1.4",
     ],
     extras_require={"dev": ["ipdb", "pylint", "nose"]},
     entry_points="""

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -44,6 +44,8 @@ def stream_report(report_url, user, password):
         for chunk in resp.iter_content(chunk_size=512):           
             if report_entry_key in chunk:
                 found_key = True
+            # Code changes to convert chunk from byte to Str
+            # So that the code changes will be compatible with python version 3.9.6
             chunk = chunk.decode("utf-8")
             coro.send(chunk)
             for rec in records:

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -1,5 +1,6 @@
 import requests
-import ijson
+import ijson.backends.yajl2_c as ijson
+import ijson as ijson_core
 
 
 def stream_report(report_url, user, password):
@@ -37,7 +38,7 @@ def stream_report(report_url, user, password):
         # 'Report_Entry' key because if we do not find it the parser
         # yields 0 records instead of failing and this allows us to know
         # if the schema is changed
-        records = ijson.sendable_list()
+        records = ijson_core.sendable_list()
         coro = ijson.items_coro(records, search_prefix)
 
         found_key = False

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -42,7 +42,7 @@ def stream_report(report_url, user, password):
         coro = ijson.items_coro(records, search_prefix)
 
         found_key = False
-        for chunk in resp.iter_content(chunk_size=512):           
+        for chunk in resp.iter_content(chunk_size=512):
             if report_entry_key in chunk:
                 found_key = True
             # Code changes to convert chunk from byte to Str

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -46,7 +46,6 @@ def stream_report(report_url, user, password):
                 found_key = True
             # Code changes to convert chunk from byte to Str
             # So that the code changes will be compatible with python version 3.9.6
-            chunk = chunk.decode("utf-8")
             coro.send(chunk)
             for rec in records:
                 yield rec

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -44,10 +44,6 @@ def stream_report(report_url, user, password):
         for chunk in resp.iter_content(chunk_size=512):           
             if report_entry_key in chunk:
                 found_key = True
-            """
-            Code changes to convert chunk from byte to Str
-            So that the code changes will be compatible with python version 3.9.6
-            """
             chunk = chunk.decode("utf-8")
             coro.send(chunk)
             for rec in records:

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -45,8 +45,6 @@ def stream_report(report_url, user, password):
         for chunk in resp.iter_content(chunk_size=512):
             if report_entry_key in chunk:
                 found_key = True
-            # Code changes to convert chunk from byte to Str
-            # So that the code changes will be compatible with python version 3.9.6
             coro.send(chunk)
             for rec in records:
                 yield rec


### PR DESCRIPTION
# Description of change
This PR swaps the `python` backend of `ijson` for the `yajl2` backend. 

This change was made because the `python` backend expects python strings to be sent to the `ijson` parser. `yajl` supports byte objects (byte arrays?) which is what a `chunk` is from the `resp.iter_content()`

I was inspired to make this change because I noticed that with the python backend and needing to decode the bytes to a string, the chunk of json we got sometimes cut the last byte in half.

This is easier to explain with examples.

```python
Python 3.9.6 (default, Sep 27 2021, 13:45:54)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.


# Here's our example string
>>> "José"
'José'


# Here's the byte representation of the string
>>> "José".encode('utf-8')
b'Jos\xc3\xa9'


# Just a sanity check that `\xc3\xa9` is valid utf-8
>>> "José".encode('utf-8').decode('utf-8')
'José'


# Here's an example of what a stack trace has been thrown with
>>> "José".encode('utf-8')[:-1]
b'Jos\xc3'
>>> "José".encode('utf-8')[:-1].decode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 3: unexpected end of data
```

I've left the stack trace in the next section as a reference for this point. You'll notice it's calling out `0xc2` instead of my `0xc3`, but I think it's fair to say the idea is the same. I just didn't find the unicode character that starts with `0xc3`.

# Manual QA steps
 - Ran the tap with and without this change
    - With the change: 10 consecutive runs did not fail. I have no other evidence it works
    - See above 

### Without the change
```python
CRITICAL 'utf-8' codec can't decode byte 0xc2 in position 4711: unexpected end of data
Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-workday-raas/bin/tap-workday-raas", line 33, in <module>
    sys.exit(load_entry_point('tap-workday-raas', 'console_scripts', 'tap-workday-raas')())
  File "/usr/local/share/virtualenvs/tap-workday-raas/lib/python3.9/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/home/vagrant/git/tap-workday-raas/tap_workday_raas/__init__.py", line 59, in main
    do_sync(args.config, args.catalog, args.state)
  File "/home/vagrant/git/tap-workday-raas/tap_workday_raas/__init__.py", line 44, in do_sync
    counter_value = sync_report(report, stream, config)
  File "/home/vagrant/git/tap-workday-raas/tap_workday_raas/sync.py", line 27, in sync_report
    for record in stream_report(report_url, username, password):
  File "/home/vagrant/git/tap-workday-raas/tap_workday_raas/client.py", line 51, in stream_report
    chunk = chunk.decode("utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc2 in position 4711: unexpected end of data
Exception ignored in: <generator object Lexer at 0x7f86915b0350>
Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-workday-raas/lib/python3.9/site-packages/ijson/backends/python.py", line 61, in Lexer
    raise common.IncompleteJSONError('Incomplete string lexeme')
ijson.common.IncompleteJSONError: Incomplete string lexeme
```

 
# Risks
 - Low. The previous implementation seemed to work off of bytes, but because the tap now supports python v3.9.6 and not v3.5.6 the byte behavior went away. This PR adds it back.
 
# Rollback steps
 - revert this branch
