### PR TITLE
version bump to v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
+## 1.0.2
+  * Updates ijson version [#13](https://github.com/singer-io/tap-workday-raas/pull/13)
 ## 1.0.1
-  * Added Fix for boolean transformation of `0` and `1` string characters [#3](https://github.com/singer-io/tap-workday-raas/pull/10)
+  * Added Fix for boolean transformation of `0` and `1` string characters [#10](https://github.com/singer-io/tap-workday-raas/pull/10)
   * Added unit test for boolean evaluation
   * Updated CircleCi Config to resolve python version incompatibility issue
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-workday-raas",
-    version="1.0.1",
+    version="1.0.2",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
version bump pr to go along with https://github.com/singer-io/tap-workday-raas/pull/13 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
