### PR TITLE
Updated URL handling and error messaging for multi-URL connection

### DIFF
--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -11,6 +11,18 @@ from tap_workday_raas.schema_utils import infer_schema_from_value
 LOGGER = singer.get_logger()
 
 
+def _sanitize_response_text(text, max_length=500):
+    """Sanitize HTTP response text for safe logging and error aggregation."""
+    if text is None:
+        return ""
+    # Replace newlines with spaces to keep logs and aggregated messages readable
+    sanitized = " ".join(text.splitlines())
+    sanitized = sanitized.strip()
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length] + "... [truncated]"
+    return sanitized
+
+
 def _element_to_schema(element):
     elem_type = element.attrib["type"].split(":")[1]
     is_nullable = element.attrib.get("minOccurs") == "0"
@@ -161,7 +173,7 @@ def discover_streams(config):
             xsd = download_xsd(report_url, username, password)
         except requests.exceptions.HTTPError as e:
             status_code = e.response.status_code if e.response is not None else "unknown"
-            response_text = e.response.text.strip() if e.response is not None else ""
+            response_text = _sanitize_response_text(e.response.text if e.response is not None else None)
             LOGGER.error(
                 'Failed to download XSD for report "%s" (url: %s). '
                 'HTTP status: %s. Server message: %s',

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -1,6 +1,7 @@
 import json
 from xml.etree import ElementTree
 import singer
+import requests
 
 from singer import metadata
 
@@ -148,25 +149,80 @@ def discover_streams(config):
     username = config["username"]
     password = config["password"]
 
+    failed_reports = []
+
     for report in reports:
-        LOGGER.info('Downloading XSD to determine table schema "%s".', report["report_name"])
+        report_name = report["report_name"]
+        report_url = report["report_url"]
 
-        xsd = download_xsd(report["report_url"], username, password)
-        schema = generate_schema_for_report(xsd)
+        LOGGER.info('Downloading XSD to determine table schema "%s"', report_name)
 
-        LOGGER.info('Enriching schema with columns from data for "%s".', report["report_name"])
-        schema = enrich_schema_from_data(schema, report["report_url"], username, password)
+        try:
+            xsd = download_xsd(report_url, username, password)
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else "unknown"
+            response_text = e.response.text.strip() if e.response is not None else ""
+            LOGGER.error(
+                'Failed to download XSD for report "%s" (url: %s). '
+                'HTTP status: %s. Server message: %s',
+                report_name, report_url, status_code, response_text or "(no response body)"
+            )
+            failed_reports.append(
+                'Report "{name}" (url: {url}) - HTTP {status}: {msg}'.format(
+                    name=report_name,
+                    url=report_url,
+                    status=status_code,
+                    msg=response_text or "(no response body)",
+                )
+            )
+            continue
+        except Exception as e:
+            LOGGER.error(
+                'Unexpected error downloading XSD for report "%s" (url: %s): %s',
+                report_name, report_url, str(e)
+            )
+            failed_reports.append(
+                'Report "{name}" (url: {url}) - {err}'.format(
+                    name=report_name, url=report_url, err=str(e)
+                )
+            )
+            continue
+
+        try:
+            schema = generate_schema_for_report(xsd)
+        except Exception as e:
+            LOGGER.error(
+                'Failed to generate schema for report "%s" (url: %s): %s',
+                report_name, report_url, str(e)
+            )
+            failed_reports.append(
+                'Report "{name}" (url: {url}) - schema generation error: {err}'.format(
+                    name=report_name, url=report_url, err=str(e)
+                )
+            )
+            continue
+
+        LOGGER.info('Enriching schema with columns from data for "%s".', report_name)
+        schema = enrich_schema_from_data(schema, report_url, username, password)
 
         stream_md = metadata.get_standard_metadata(schema,
                                                    key_properties=report.get("key_properties"),
                                                    replication_method="FULL_TABLE")
         streams.append(
             {
-                "stream": report["report_name"],
-                "tap_stream_id": report["report_name"],
+                "stream": report_name,
+                "tap_stream_id": report_name,
                 "schema": schema,
                 "metadata": stream_md
             }
+        )
+
+    if failed_reports:
+        raise Exception(
+            "Discovery failed for {} report(s):\n{}".format(
+                len(failed_reports),
+                "\n".join("  - {}".format(r) for r in failed_reports)
+            )
         )
 
     return streams

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,5 +1,7 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+from unittest import mock
+import requests
 from tap_workday_raas import discover
 
 
@@ -251,3 +253,184 @@ class TestDiscoverStreamsEnrichment(unittest.TestCase):
         }
         discover.discover_streams(config)
         mock_enrich.assert_called_once()
+
+
+def _make_http_error(status_code, response_text="Server Error"):
+    """Helper to construct a requests.exceptions.HTTPError with a mock response."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.text = response_text
+    error = requests.exceptions.HTTPError(response=mock_response)
+    return error
+
+
+class TestDiscoverStreamsErrorHandling(unittest.TestCase):
+    """Test per-report error handling in discover_streams."""
+
+    def _config(self, reports):
+        import json
+        return {
+            "username": "user",
+            "password": "pass",
+            "reports": json.dumps(reports),
+        }
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_all_reports_succeed_returns_streams(self, mock_xsd, mock_enrich):
+        """When all reports succeed, discover_streams returns all streams without raising."""
+        mock_xsd.return_value = xsd
+        mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+        streams = discover.discover_streams(config)
+
+        self.assertEqual(len(streams), 2)
+        stream_ids = [s["tap_stream_id"] for s in streams]
+        self.assertIn("report_1", stream_ids)
+        self.assertIn("report_2", stream_ids)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_single_http_error_raises_with_status_code(self, mock_xsd, mock_enrich):
+        """An HTTP error on download_xsd raises an exception containing the status code."""
+        mock_xsd.side_effect = _make_http_error(500, "Internal Server Error")
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        self.assertIn("500", str(ctx.exception))
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_http_error_message_contains_report_name_and_url(self, mock_xsd, mock_enrich):
+        """The raised exception message includes the report name and URL."""
+        mock_xsd.side_effect = _make_http_error(403, "Forbidden")
+
+        config = self._config([
+            {"report_url": "http://fake/secret_report", "report_name": "secret_report"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("secret_report", error_msg)
+        self.assertIn("http://fake/secret_report", error_msg)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_http_error_message_contains_server_response_text(self, mock_xsd, mock_enrich):
+        """The raised exception includes the server's response body text."""
+        mock_xsd.side_effect = _make_http_error(500, "The report does not exist.")
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        self.assertIn("The report does not exist.", str(ctx.exception))
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_one_failing_report_does_not_prevent_others(self, mock_xsd, mock_enrich):
+        """A failing report is skipped and remaining reports are still discovered."""
+        mock_xsd.side_effect = [
+            _make_http_error(500, "Error"),   # report_1 fails
+            xsd,                               # report_2 succeeds
+        ]
+        mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            streams = discover.discover_streams(config)
+
+        # The exception should only mention the failed report
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)
+        self.assertNotIn("report_2", error_msg)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_one_failing_report_still_discovers_others(self, mock_xsd, mock_enrich):
+        """Streams from successful reports are still discoverable even when another fails."""
+        mock_xsd.side_effect = [
+            xsd,                               # report_1 succeeds
+            _make_http_error(404, "Not Found"), # report_2 fails
+        ]
+        mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+
+        discovered_streams = []
+        try:
+            discover.discover_streams(config)
+        except Exception:
+            pass  # expected – but we can't check streams since it raises not returns
+
+        # Verify that download_xsd was called for both reports (loop continued)
+        self.assertEqual(mock_xsd.call_count, 2)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_multiple_failing_reports_all_listed_in_exception(self, mock_xsd, mock_enrich):
+        """When multiple reports fail, all of them are listed in a single exception."""
+        mock_xsd.side_effect = [
+            _make_http_error(500, "Error A"),
+            _make_http_error(403, "Error B"),
+        ]
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)
+        self.assertIn("report_2", error_msg)
+        self.assertIn("2", error_msg)  # "Discovery failed for 2 report(s)"
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_non_http_error_on_download_xsd_is_caught(self, mock_xsd, mock_enrich):
+        """Non-HTTP exceptions (e.g. connection error) from download_xsd are also handled."""
+        mock_xsd.side_effect = ConnectionError("DNS resolution failed")
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)
+        self.assertIn("DNS resolution failed", error_msg)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_schema_generation_failure_is_caught(self, mock_xsd, mock_enrich):
+        """If generate_schema_for_report raises, the report is skipped and error is raised at end."""
+        mock_xsd.return_value = "invalid xsd"  # will cause generate_schema_for_report to fail
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from unittest import mock
 import requests
 from tap_workday_raas import discover
 
@@ -352,7 +351,7 @@ class TestDiscoverStreamsErrorHandling(unittest.TestCase):
             {"report_url": "http://fake/r2", "report_name": "report_2"},
         ])
         with self.assertRaises(Exception) as ctx:
-            streams = discover.discover_streams(config)
+            discover.discover_streams(config)
 
         # The exception should only mention the failed report
         error_msg = str(ctx.exception)
@@ -374,7 +373,6 @@ class TestDiscoverStreamsErrorHandling(unittest.TestCase):
             {"report_url": "http://fake/r2", "report_name": "report_2"},
         ])
 
-        discovered_streams = []
         try:
             discover.discover_streams(config)
         except Exception:


### PR DESCRIPTION
# Description of change
PR included per-report error isolation added to `discover_streams`. Previously, a single URL failure crashed the entire discovery run, silently skipping all remaining reports.
After all report urls are processed, a single consolidated exception is raised listing all failures.
Added unittest covering HTTP errors, non-HTTP errors, partial failures, multi-report failures, and schema generation errors.
[SAC-30061](https://qlik-dev.atlassian.net/browse/SAC-30061)

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
