### PR TITLE
Include null-only columns in metadata (#23)

### DIFF
--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -1,6 +1,9 @@
 import requests
 import ijson.backends.yajl2_c as ijson
 import ijson as ijson_core
+import singer
+
+LOGGER = singer.get_logger()
 
 
 def stream_report(report_url, user, password):
@@ -41,19 +44,51 @@ def stream_report(report_url, user, password):
         records = ijson_core.sendable_list()
         coro = ijson.items_coro(records, search_prefix)
 
-        found_key = False
+        # Track key presence using an ijson event parser so we are not
+        # vulnerable to the key name being split across chunk boundaries
+        # (raw byte scanning of small chunks could miss it).
+        key_events = ijson_core.sendable_list()
+        key_coro = ijson.parse_coro(key_events)
+        found_report_entry = False
+        response_is_json_object = False
+
         for chunk in resp.iter_content(chunk_size=512):
-            if report_entry_key in chunk:
-                found_key = True
             coro.send(chunk)
+            key_coro.send(chunk)
+
+            # Scan parser events returned so far for the keys we care about
+            for prefix, event, _value in key_events:
+                if prefix == "" and event == "start_map":
+                    response_is_json_object = True
+                elif prefix == "" and event == "map_key" and _value == report_entry_key.decode("utf-8"):
+                    found_report_entry = True
+            del key_events[:]
+
             for rec in records:
                 yield rec
             del records[:]
 
-        if not found_key:
-            raise Exception("Did not see '{}' key in response. Report does not conform to expected schema, failing.".format(report_entry_key))
+        if not found_report_entry:
+            if response_is_json_object:
+                # The response is valid JSON but does not contain the
+                # Report_Entry key.  This is the standard Workday zero-row
+                # response – log a warning and continue.
+                LOGGER.warning(
+                    "Did not see '%s' key in response. "
+                    "Report returned 0 rows (empty result set).",
+                    report_entry_key.decode("utf-8"),
+                )
+            else:
+                # Unexpected payload – the response is not even a JSON
+                # object.  This likely indicates an API error.
+                raise Exception(
+                    "Did not see '{}' key in response. "
+                    "Report does not conform to expected schema, failing."
+                    .format(report_entry_key.decode("utf-8"))
+                )
 
         coro.close()
+        key_coro.close()
 
 
 def download_xsd(report_url, user, password):

--- a/tap_workday_raas/client.py
+++ b/tap_workday_raas/client.py
@@ -27,6 +27,10 @@ def stream_report(report_url, user, password):
 
     # Get the data
     with requests.get(corrected_url, auth=(user, password), stream=True) as resp:
+        if not resp.ok:
+            # Force-read the error response body before raise_for_status() closes
+            # the connection, so e.response.text is accessible to callers.
+            _ = resp.content
         resp.raise_for_status()
 
         # Set up our search key

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -1,12 +1,26 @@
 import json
 from xml.etree import ElementTree
 import singer
+import requests
 
 from singer import metadata
 
-from tap_workday_raas.client import download_xsd
+from tap_workday_raas.client import download_xsd, stream_report
+from tap_workday_raas.schema_utils import infer_schema_from_value
 
 LOGGER = singer.get_logger()
+
+
+def _sanitize_response_text(text, max_length=500):
+    """Sanitize HTTP response text for safe logging and error aggregation."""
+    if text is None:
+        return ""
+    # Replace newlines with spaces to keep logs and aggregated messages readable
+    sanitized = " ".join(text.splitlines())
+    sanitized = sanitized.strip()
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length] + "... [truncated]"
+    return sanitized
 
 
 def _element_to_schema(element):
@@ -33,7 +47,10 @@ def _element_to_schema(element):
         schema["type"].append("null")
 
     if is_list:
-        schema = {"type": "array", "items": schema}
+        if is_nullable:
+            schema = {"type": ["array", "null"], "items": schema}
+        else:
+            schema = {"type": "array", "items": schema}
 
     return schema
 
@@ -81,9 +98,13 @@ def generate_schema_for_report(xsd):
                 raise Exception("Found unexpected value for maxOccurs attribute: '{}'".format(max_occurs))
 
             is_list = max_occurs == "unbounded"
+            is_nullable = elem.attrib.get("minOccurs") == "0"
 
             if is_list:
-                elem_schema = {"type": "array", "items": complex_type_mapping[elem_type]}
+                if is_nullable:
+                    elem_schema = {"type": ["array", "null"], "items": complex_type_mapping[elem_type]}
+                else:
+                    elem_schema = {"type": "array", "items": complex_type_mapping[elem_type]}
             else:
                 elem_schema = complex_type_mapping[elem_type]
             schema["properties"][elem_name] = elem_schema
@@ -91,6 +112,44 @@ def generate_schema_for_report(xsd):
             schema_type = _element_to_schema(elem)
 
             schema["properties"][elem_name] = {**schema_type}
+    return schema
+
+
+def enrich_schema_from_data(schema, report_url, username, password, sample_size=100):
+    """Enrich schema with column definitions found in actual report data but missing from XSD.
+
+    Workday's XSD endpoint may omit columns where all rows contain null values.
+    This function samples actual JSON data and adds any additional columns found
+    to the schema, defaulting to their inferred type (or nullable string for None).
+    """
+    if sample_size <= 0:
+        return schema
+
+    try:
+        all_columns = {}  # column_name -> first non-None sample value
+        for i, record in enumerate(stream_report(report_url, username, password)):
+            for key, value in record.items():
+                if key not in all_columns or all_columns[key] is None:
+                    all_columns[key] = value
+            if i >= sample_size - 1:
+                break
+
+        for col, sample_value in all_columns.items():
+            if col not in schema["properties"]:
+                inferred_schema = infer_schema_from_value(sample_value)
+                LOGGER.info(
+                    'Found column "%s" in data not in XSD schema. '
+                    'Adding with inferred type: %s',
+                    col, inferred_schema
+                )
+                schema["properties"][col] = inferred_schema
+    except Exception as e:
+        LOGGER.warning(
+            "Could not enrich schema from data sampling: %s. "
+            "Continuing with schema from XSD only.",
+            str(e)
+        )
+
     return schema
 
 
@@ -102,22 +161,80 @@ def discover_streams(config):
     username = config["username"]
     password = config["password"]
 
-    for report in reports:
-        LOGGER.info('Downloading XSD to determine table schema "%s".', report["report_name"])
+    failed_reports = []
 
-        xsd = download_xsd(report["report_url"], username, password)
-        schema = generate_schema_for_report(xsd)
+    for report in reports:
+        report_name = report["report_name"]
+        report_url = report["report_url"]
+
+        LOGGER.info('Downloading XSD to determine table schema "%s"', report_name)
+
+        try:
+            xsd = download_xsd(report_url, username, password)
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else "unknown"
+            response_text = _sanitize_response_text(e.response.text if e.response is not None else None)
+            LOGGER.error(
+                'Failed to download XSD for report "%s" (url: %s). '
+                'HTTP status: %s. Server message: %s',
+                report_name, report_url, status_code, response_text or "(no response body)"
+            )
+            failed_reports.append(
+                'Report "{name}" (url: {url}) - HTTP {status}: {msg}'.format(
+                    name=report_name,
+                    url=report_url,
+                    status=status_code,
+                    msg=response_text or "(no response body)",
+                )
+            )
+            continue
+        except Exception as e:
+            LOGGER.error(
+                'Unexpected error downloading XSD for report "%s" (url: %s): %s',
+                report_name, report_url, str(e)
+            )
+            failed_reports.append(
+                'Report "{name}" (url: {url}) - {err}'.format(
+                    name=report_name, url=report_url, err=str(e)
+                )
+            )
+            continue
+
+        try:
+            schema = generate_schema_for_report(xsd)
+        except Exception as e:
+            LOGGER.error(
+                'Failed to generate schema for report "%s" (url: %s): %s',
+                report_name, report_url, str(e)
+            )
+            failed_reports.append(
+                'Report "{name}" (url: {url}) - schema generation error: {err}'.format(
+                    name=report_name, url=report_url, err=str(e)
+                )
+            )
+            continue
+
+        LOGGER.info('Enriching schema with columns from data for "%s".', report_name)
+        schema = enrich_schema_from_data(schema, report_url, username, password)
 
         stream_md = metadata.get_standard_metadata(schema,
                                                    key_properties=report.get("key_properties"),
                                                    replication_method="FULL_TABLE")
         streams.append(
             {
-                "stream": report["report_name"],
-                "tap_stream_id": report["report_name"],
+                "stream": report_name,
+                "tap_stream_id": report_name,
                 "schema": schema,
                 "metadata": stream_md
             }
+        )
+
+    if failed_reports:
+        raise Exception(
+            "Discovery failed for {} report(s):\n{}".format(
+                len(failed_reports),
+                "\n".join("  - {}".format(r) for r in failed_reports)
+            )
         )
 
     return streams

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -162,6 +162,17 @@ def discover_streams(config):
 
     reports = json.loads(config["reports"])
 
+    report_names = [report["report_name"] for report in reports]
+    seen = set()
+    duplicates = {name for name in report_names if name in seen or seen.add(name)}
+    if duplicates:
+        raise ValueError(
+            "Duplicate report name(s) found in config: {}. "
+            "Each report_name must be unique as it is used as the stream name.".format(
+                ", ".join(sorted(duplicates))
+            )
+        )
+
     username = config["username"]
     password = config["password"]
 

--- a/tap_workday_raas/discover.py
+++ b/tap_workday_raas/discover.py
@@ -143,6 +143,10 @@ def enrich_schema_from_data(schema, report_url, username, password, sample_size=
                     col, inferred_schema
                 )
                 schema["properties"][col] = inferred_schema
+    except requests.exceptions.HTTPError:
+        # HTTP errors (e.g. 403, 500) are fatal for this report – re-raise so
+        # discover_streams can catch them per-report and surface a clear message.
+        raise
     except Exception as e:
         LOGGER.warning(
             "Could not enrich schema from data sampling: %s. "
@@ -180,7 +184,7 @@ def discover_streams(config):
                 report_name, report_url, status_code, response_text or "(no response body)"
             )
             failed_reports.append(
-                'Report "{name}" (url: {url}) - HTTP {status}: {msg}'.format(
+                'Report "{name}" (url: {url}) - [schema download] HTTP {status}: {msg}'.format(
                     name=report_name,
                     url=report_url,
                     status=status_code,
@@ -194,7 +198,7 @@ def discover_streams(config):
                 report_name, report_url, str(e)
             )
             failed_reports.append(
-                'Report "{name}" (url: {url}) - {err}'.format(
+                'Report "{name}" (url: {url}) - [schema download] {err}'.format(
                     name=report_name, url=report_url, err=str(e)
                 )
             )
@@ -215,7 +219,25 @@ def discover_streams(config):
             continue
 
         LOGGER.info('Enriching schema with columns from data for "%s".', report_name)
-        schema = enrich_schema_from_data(schema, report_url, username, password)
+        try:
+            schema = enrich_schema_from_data(schema, report_url, username, password)
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else "unknown"
+            response_text = _sanitize_response_text(e.response.text if e.response is not None else None)
+            LOGGER.error(
+                'Failed to fetch report data for "%s" (url: %s). '
+                'HTTP status: %s. Server message: %s',
+                report_name, report_url, status_code, response_text or "(no response body)"
+            )
+            failed_reports.append(
+                'Report "{name}" (url: {url}) - [data fetch] HTTP {status}: {msg}'.format(
+                    name=report_name,
+                    url=report_url,
+                    status=status_code,
+                    msg=response_text or "(no response body)",
+                )
+            )
+            continue
 
         stream_md = metadata.get_standard_metadata(schema,
                                                    key_properties=report.get("key_properties"),

--- a/tap_workday_raas/schema_utils.py
+++ b/tap_workday_raas/schema_utils.py
@@ -1,0 +1,26 @@
+def infer_schema_from_value(value):
+    """Infer JSON schema type from a sample Python value.
+
+    Used when a column is found in data but not in the XSD schema,
+    both during discovery enrichment and sync-time schema expansion.
+    Defaults to nullable string for None values.
+    """
+    if value is None:
+        return {"type": ["string", "null"]}
+    elif isinstance(value, bool):
+        return {"type": ["boolean", "null"]}
+    elif isinstance(value, (int, float)):
+        return {"type": ["number", "null"]}
+    elif isinstance(value, dict):
+        properties = {}
+        for k, v in value.items():
+            properties[k] = infer_schema_from_value(v)
+        return {"type": "object", "properties": properties}
+    elif isinstance(value, list):
+        if value:
+            items_schema = infer_schema_from_value(value[0])
+        else:
+            items_schema = {"type": ["string", "null"]}
+        return {"type": "array", "items": items_schema}
+    else:
+        return {"type": ["string", "null"]}

--- a/tap_workday_raas/sync.py
+++ b/tap_workday_raas/sync.py
@@ -3,6 +3,7 @@ import singer
 from singer import metadata, utils
 from .transform import WorkdayTransformer as Transformer
 from .client import stream_report
+from .schema_utils import infer_schema_from_value
 
 LOGGER = singer.get_logger()
 
@@ -16,19 +17,48 @@ def sync_report(report, stream, config):
 
     record_count = 0
 
-    record = {}
-
     stream_version = int(time.time() * 1000)
     extraction_time = utils.now().isoformat()
+
+    schema = stream.schema.to_dict()
+    if "properties" not in schema:
+        schema["properties"] = {}
+    schema_properties = schema["properties"]
+    mdata = metadata.to_map(stream.metadata)
+    key_properties = metadata.get(mdata, (), "table-key-properties") or []
 
     singer.write_version(stream.tap_stream_id, stream_version)
 
     with Transformer() as transformer:
         for record in stream_report(report_url, username, password):
-            to_write = transformer.transform(record, stream.schema.to_dict(), metadata.to_map(stream.metadata))
+            # Detect columns in the record that are not yet in the schema
+            new_columns = set(record.keys()) - set(schema_properties.keys())
+            if new_columns:
+                for col in new_columns:
+                    inferred = infer_schema_from_value(record[col])
+                    schema_properties[col] = inferred
+                    LOGGER.info(
+                        'Found new column "%s" in data not in schema. '
+                        'Adding with inferred type: %s',
+                        col, inferred
+                    )
+                # Re-emit the schema so the target knows about the new columns
+                singer.write_schema(stream.tap_stream_id, schema, key_properties)
+
+            to_write = transformer.transform(record, schema, mdata)
+
+            # Ensure every schema property appears in the output record;
+            # columns missing from this particular record are emitted as null
+            for prop in schema_properties:
+                if prop not in to_write:
+                    to_write[prop] = None
+
             to_write["_sdc_extracted_at"] = extraction_time
             record_message = singer.RecordMessage(stream.tap_stream_id, to_write, version=stream_version)
             singer.write_message(record_message)
             record_count += 1
+
+    if record_count == 0:
+        LOGGER.info('Report "%s" returned 0 rows. Completing successfully with empty result set.', report_url)
 
     return record_count

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import patch, MagicMock
+import requests
 from tap_workday_raas import discover
 
 
@@ -48,7 +50,7 @@ class DiscoveryTest(unittest.TestCase):
                                                                  'Potential': {'type': ['string', 'null']},
                                                                  'Willing_To_Travel': {'type': ['string', 'null']}},
                                                   'type': 'object'},
-                                                 'type': 'array'},
+                                                 'type': ['array', 'null']},
                      'Default_Assessment_Tests': {'type': ['string', 'null']},
                      'Default_Job_Title': {'type': ['string', 'null']},
                      'Languages': {'type': ['string', 'null']},
@@ -56,5 +58,377 @@ class DiscoveryTest(unittest.TestCase):
                     'type': 'object'}
 
         actual = discover.generate_schema_for_report(xsd)
-        
         self.assertEqual(expected, actual)
+
+
+class TestInferSchemaFromValue(unittest.TestCase):
+    """Test infer_schema_from_value type inference for various Python values."""
+
+    def test_none_returns_nullable_string(self):
+        result = discover.infer_schema_from_value(None)
+        self.assertEqual(result, {"type": ["string", "null"]})
+
+    def test_string_returns_nullable_string(self):
+        result = discover.infer_schema_from_value("hello")
+        self.assertEqual(result, {"type": ["string", "null"]})
+
+    def test_bool_returns_nullable_boolean(self):
+        result = discover.infer_schema_from_value(True)
+        self.assertEqual(result, {"type": ["boolean", "null"]})
+
+    def test_int_returns_nullable_number(self):
+        result = discover.infer_schema_from_value(42)
+        self.assertEqual(result, {"type": ["number", "null"]})
+
+    def test_float_returns_nullable_number(self):
+        result = discover.infer_schema_from_value(3.14)
+        self.assertEqual(result, {"type": ["number", "null"]})
+
+    def test_dict_returns_object_with_properties(self):
+        result = discover.infer_schema_from_value({"name": "Alice", "age": 30})
+        self.assertEqual(result, {
+            "type": "object",
+            "properties": {
+                "name": {"type": ["string", "null"]},
+                "age": {"type": ["number", "null"]},
+            }
+        })
+
+    def test_list_returns_array_with_item_type(self):
+        result = discover.infer_schema_from_value(["a", "b"])
+        self.assertEqual(result, {
+            "type": "array",
+            "items": {"type": ["string", "null"]}
+        })
+
+    def test_empty_list_returns_array_with_nullable_string_items(self):
+        result = discover.infer_schema_from_value([])
+        self.assertEqual(result, {
+            "type": "array",
+            "items": {"type": ["string", "null"]}
+        })
+
+
+class TestEnrichSchemaFromData(unittest.TestCase):
+    """Test enrich_schema_from_data merging of data-discovered columns into schema."""
+
+    def _base_schema(self):
+        """Return a minimal schema with two known columns."""
+        return {
+            "type": "object",
+            "properties": {
+                "col_a": {"type": ["string", "null"]},
+                "col_b": {"type": ["number", "null"]},
+            }
+        }
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_adds_columns_found_in_data_but_not_in_xsd(self, mock_stream):
+        """Columns present in JSON records but missing from XSD are added to schema."""
+        mock_stream.return_value = iter([
+            {"col_a": "v1", "col_b": 1, "col_c": "extra", "col_d": 99},
+        ])
+        schema = self._base_schema()
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p")
+
+        self.assertIn("col_c", result["properties"])
+        self.assertEqual(result["properties"]["col_c"], {"type": ["string", "null"]})
+        self.assertIn("col_d", result["properties"])
+        self.assertEqual(result["properties"]["col_d"], {"type": ["number", "null"]})
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_does_not_overwrite_existing_xsd_columns(self, mock_stream):
+        """Columns already in the XSD schema retain their original type definition."""
+        mock_stream.return_value = iter([
+            {"col_a": 12345, "col_b": "string_value"},
+        ])
+        schema = self._base_schema()
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p")
+
+        # Original types should be preserved, not overwritten by inferred types
+        self.assertEqual(result["properties"]["col_a"], {"type": ["string", "null"]})
+        self.assertEqual(result["properties"]["col_b"], {"type": ["number", "null"]})
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_no_extra_columns_leaves_schema_unchanged(self, mock_stream):
+        """When data has exactly the same columns as XSD, schema is unchanged."""
+        mock_stream.return_value = iter([
+            {"col_a": "v1", "col_b": 42},
+        ])
+        schema = self._base_schema()
+        original_props = dict(schema["properties"])
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p")
+
+        self.assertEqual(result["properties"], original_props)
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_handles_stream_report_error_gracefully(self, mock_stream):
+        """If stream_report raises an exception, the original schema is returned."""
+        mock_stream.side_effect = Exception("connection refused")
+        schema = self._base_schema()
+        original_props = dict(schema["properties"])
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p")
+
+        self.assertEqual(result["properties"], original_props)
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_handles_empty_data(self, mock_stream):
+        """If the report returns zero records, schema is unchanged."""
+        mock_stream.return_value = iter([])
+        schema = self._base_schema()
+        original_props = dict(schema["properties"])
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p")
+
+        self.assertEqual(result["properties"], original_props)
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_collects_columns_across_multiple_records(self, mock_stream):
+        """Columns that appear in different records are all captured."""
+        mock_stream.return_value = iter([
+            {"col_a": "v1"},
+            {"col_a": "v2", "col_c": "extra1"},
+            {"col_a": "v3", "col_d": 100},
+        ])
+        schema = self._base_schema()
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p")
+
+        self.assertIn("col_c", result["properties"])
+        self.assertIn("col_d", result["properties"])
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_prefers_non_none_value_for_type_inference(self, mock_stream):
+        """When a column is None in early records, a later non-None value is used for inference."""
+        mock_stream.return_value = iter([
+            {"col_a": "v1", "col_new": None},
+            {"col_a": "v2", "col_new": 42},
+        ])
+        schema = self._base_schema()
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p")
+
+        self.assertIn("col_new", result["properties"])
+        self.assertEqual(result["properties"]["col_new"], {"type": ["number", "null"]})
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_sample_size_limits_records_read(self, mock_stream):
+        """Only sample_size records should be consumed from the stream."""
+        consumed = []
+        def counting_iter():
+            for i in range(200):
+                consumed.append(i)
+                yield {"col_a": f"v{i}"}
+
+        mock_stream.return_value = counting_iter()
+        schema = self._base_schema()
+
+        discover.enrich_schema_from_data(schema, "http://fake", "u", "p", sample_size=5)
+
+        self.assertEqual(len(consumed), 5, "Should consume exactly sample_size records")
+
+    @patch("tap_workday_raas.discover.stream_report")
+    def test_sample_size_zero_skips_data_fetch(self, mock_stream):
+        """When sample_size is 0, no records should be fetched and schema is unchanged."""
+        schema = self._base_schema()
+        original_props = dict(schema["properties"])
+        result = discover.enrich_schema_from_data(schema, "http://fake", "u", "p", sample_size=0)
+
+        mock_stream.assert_not_called()
+        self.assertEqual(result["properties"], original_props)
+
+
+class TestDiscoverStreamsEnrichment(unittest.TestCase):
+    """Test discover_streams always enriches schema from data."""
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_enrich_schema_always_called(self, mock_xsd, mock_enrich):
+        """enrich_schema_from_data is always called during discovery."""
+        mock_xsd.return_value = xsd
+        mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+        config = {
+            "username": "user",
+            "password": "pass",
+            "reports": '[{"report_url": "http://fake", "report_name": "test_report"}]',
+        }
+        discover.discover_streams(config)
+        mock_enrich.assert_called_once()
+
+
+def _make_http_error(status_code, response_text="Server Error"):
+    """Helper to construct a requests.exceptions.HTTPError with a mock response."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.text = response_text
+    error = requests.exceptions.HTTPError(response=mock_response)
+    return error
+
+
+class TestDiscoverStreamsErrorHandling(unittest.TestCase):
+    """Test per-report error handling in discover_streams."""
+
+    def _config(self, reports):
+        import json
+        return {
+            "username": "user",
+            "password": "pass",
+            "reports": json.dumps(reports),
+        }
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_all_reports_succeed_returns_streams(self, mock_xsd, mock_enrich):
+        """When all reports succeed, discover_streams returns all streams without raising."""
+        mock_xsd.return_value = xsd
+        mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+        streams = discover.discover_streams(config)
+
+        self.assertEqual(len(streams), 2)
+        stream_ids = [s["tap_stream_id"] for s in streams]
+        self.assertIn("report_1", stream_ids)
+        self.assertIn("report_2", stream_ids)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_single_http_error_raises_with_status_code(self, mock_xsd, mock_enrich):
+        """An HTTP error on download_xsd raises an exception containing the status code."""
+        mock_xsd.side_effect = _make_http_error(500, "Internal Server Error")
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        self.assertIn("500", str(ctx.exception))
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_http_error_message_contains_report_name_and_url(self, mock_xsd, mock_enrich):
+        """The raised exception message includes the report name and URL."""
+        mock_xsd.side_effect = _make_http_error(403, "Forbidden")
+
+        config = self._config([
+            {"report_url": "http://fake/secret_report", "report_name": "secret_report"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("secret_report", error_msg)
+        self.assertIn("http://fake/secret_report", error_msg)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_http_error_message_contains_server_response_text(self, mock_xsd, mock_enrich):
+        """The raised exception includes the server's response body text."""
+        mock_xsd.side_effect = _make_http_error(500, "The report does not exist.")
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        self.assertIn("The report does not exist.", str(ctx.exception))
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_one_failing_report_does_not_prevent_others(self, mock_xsd, mock_enrich):
+        """A failing report is skipped and remaining reports are still discovered."""
+        mock_xsd.side_effect = [
+            _make_http_error(500, "Error"),   # report_1 fails
+            xsd,                               # report_2 succeeds
+        ]
+        mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        # The exception should only mention the failed report
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)
+        self.assertNotIn("report_2", error_msg)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_one_failing_report_still_discovers_others(self, mock_xsd, mock_enrich):
+        """Streams from successful reports are still discoverable even when another fails."""
+        mock_xsd.side_effect = [
+            xsd,                               # report_1 succeeds
+            _make_http_error(404, "Not Found"), # report_2 fails
+        ]
+        mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+
+        try:
+            discover.discover_streams(config)
+        except Exception:
+            pass  # expected – but we can't check streams since it raises not returns
+
+        # Verify that download_xsd was called for both reports (loop continued)
+        self.assertEqual(mock_xsd.call_count, 2)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_multiple_failing_reports_all_listed_in_exception(self, mock_xsd, mock_enrich):
+        """When multiple reports fail, all of them are listed in a single exception."""
+        mock_xsd.side_effect = [
+            _make_http_error(500, "Error A"),
+            _make_http_error(403, "Error B"),
+        ]
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+            {"report_url": "http://fake/r2", "report_name": "report_2"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)
+        self.assertIn("report_2", error_msg)
+        self.assertIn("2", error_msg)  # "Discovery failed for 2 report(s)"
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_non_http_error_on_download_xsd_is_caught(self, mock_xsd, mock_enrich):
+        """Non-HTTP exceptions (e.g. connection error) from download_xsd are also handled."""
+        mock_xsd.side_effect = ConnectionError("DNS resolution failed")
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)
+        self.assertIn("DNS resolution failed", error_msg)
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_schema_generation_failure_is_caught(self, mock_xsd, mock_enrich):
+        """If generate_schema_for_report raises, the report is skipped and error is raised at end."""
+        mock_xsd.return_value = "invalid xsd"  # will cause generate_schema_for_report to fail
+
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_1"},
+        ])
+        with self.assertRaises(Exception) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("report_1", error_msg)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -263,6 +263,63 @@ def _make_http_error(status_code, response_text="Server Error"):
     return error
 
 
+class TestDiscoverStreamsDuplicateReportNames(unittest.TestCase):
+    """Test that duplicate report names are rejected during discovery."""
+
+    def _config(self, reports):
+        import json
+        return {
+            "username": "user",
+            "password": "pass",
+            "reports": json.dumps(reports),
+        }
+
+    def test_duplicate_report_names_raises_value_error(self):
+        """discover_streams raises ValueError when two reports share the same name."""
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "my_report"},
+            {"report_url": "http://fake/r2", "report_name": "my_report"},
+        ])
+        with self.assertRaises(ValueError) as ctx:
+            discover.discover_streams(config)
+
+        self.assertIn("my_report", str(ctx.exception))
+
+    def test_multiple_duplicate_report_names_all_listed(self):
+        """All duplicate names are included in the error message."""
+        config = self._config([
+            {"report_url": "http://fake/r1", "report_name": "report_a"},
+            {"report_url": "http://fake/r2", "report_name": "report_b"},
+            {"report_url": "http://fake/r3", "report_name": "report_a"},
+            {"report_url": "http://fake/r4", "report_name": "report_b"},
+        ])
+        with self.assertRaises(ValueError) as ctx:
+            discover.discover_streams(config)
+
+        error_msg = str(ctx.exception)
+        self.assertIn("report_a", error_msg)
+        self.assertIn("report_b", error_msg)
+
+    def test_unique_report_names_does_not_raise(self):
+        """No error is raised when all report names are unique."""
+        from unittest.mock import patch
+        with patch("tap_workday_raas.discover.download_xsd") as mock_xsd, \
+             patch("tap_workday_raas.discover.enrich_schema_from_data") as mock_enrich:
+            import xml.etree.ElementTree as ET
+            mock_xsd.return_value = xsd
+            mock_enrich.side_effect = lambda schema, *a, **kw: schema
+
+            config = self._config([
+                {"report_url": "http://fake/r1", "report_name": "report_x"},
+                {"report_url": "http://fake/r2", "report_name": "report_y"},
+            ])
+            # Should not raise
+            streams = discover.discover_streams(config)
+            stream_names = [s["tap_stream_id"] for s in streams]
+            self.assertIn("report_x", stream_names)
+            self.assertIn("report_y", stream_names)
+
+
 class TestDiscoverStreamsErrorHandling(unittest.TestCase):
     """Test per-report error handling in discover_streams."""
 

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,340 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_workday_raas.sync import sync_report
+from tap_workday_raas.schema_utils import infer_schema_from_value
+
+
+# ---------------------------------------------------------------------------
+# Tests for infer_schema_from_value
+# ---------------------------------------------------------------------------
+
+class TestInferSchemaType(unittest.TestCase):
+    """Verify type inference used when expanding the schema during sync."""
+
+    def test_none_returns_nullable_string(self):
+        self.assertEqual(infer_schema_from_value(None), {"type": ["string", "null"]})
+
+    def test_string_returns_nullable_string(self):
+        self.assertEqual(infer_schema_from_value("hello"), {"type": ["string", "null"]})
+
+    def test_bool_returns_nullable_boolean(self):
+        self.assertEqual(infer_schema_from_value(True), {"type": ["boolean", "null"]})
+        self.assertEqual(infer_schema_from_value(False), {"type": ["boolean", "null"]})
+
+    def test_int_returns_nullable_number(self):
+        self.assertEqual(infer_schema_from_value(42), {"type": ["number", "null"]})
+
+    def test_float_returns_nullable_number(self):
+        self.assertEqual(infer_schema_from_value(3.14), {"type": ["number", "null"]})
+
+    def test_dict_returns_object(self):
+        result = infer_schema_from_value({"k": "v"})
+        self.assertEqual(result, {
+            "type": "object",
+            "properties": {"k": {"type": ["string", "null"]}}
+        })
+
+    def test_list_with_values_returns_array(self):
+        result = infer_schema_from_value(["a"])
+        self.assertEqual(result, {
+            "type": "array",
+            "items": {"type": ["string", "null"]}
+        })
+
+    def test_empty_list_returns_array_with_nullable_string_items(self):
+        result = infer_schema_from_value([])
+        self.assertEqual(result, {
+            "type": "array",
+            "items": {"type": ["string", "null"]}
+        })
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a fake Singer stream object
+# ---------------------------------------------------------------------------
+
+def _make_stream(tap_stream_id, schema, metadata_list=None):
+    """Return a mock stream object that behaves like singer.catalog.CatalogEntry."""
+    stream = MagicMock()
+    stream.tap_stream_id = tap_stream_id
+
+    schema_obj = MagicMock()
+    schema_obj.to_dict.return_value = schema
+    stream.schema = schema_obj
+
+    if metadata_list is None:
+        metadata_list = [{"breadcrumb": [], "metadata": {}}]
+    stream.metadata = metadata_list
+    return stream
+
+
+# ---------------------------------------------------------------------------
+# Tests for sync_report – schema evolution & null-filling
+# ---------------------------------------------------------------------------
+
+@patch("tap_workday_raas.sync.singer")
+@patch("tap_workday_raas.sync.stream_report")
+class TestSyncReportSchemaEvolution(unittest.TestCase):
+    """Ensure sync_report dynamically expands the schema for new columns
+    and fills null for missing columns."""
+
+    def _default_config(self):
+        return {"username": "u", "password": "p"}
+
+    def _default_report(self):
+        return {"report_url": "http://fake", "report_name": "test_report"}
+
+    # -----------------------------------------------------------------------
+    # AC-3: Data in a previously-empty column flows through without error
+    # -----------------------------------------------------------------------
+
+    def test_new_column_in_record_triggers_schema_re_emit(self, mock_stream_report, mock_singer):
+        """When a record contains a column not in the original schema,
+        write_schema should be called again with the expanded schema."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "col_a": {"type": ["string", "null"]},
+            }
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([
+            {"col_a": "v1", "col_new": "surprise"},
+        ])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        # write_schema must be called with the expanded schema
+        schema_calls = [c for c in mock_singer.write_schema.call_args_list]
+        self.assertTrue(len(schema_calls) >= 1, "write_schema should be called for new columns")
+
+        # The last schema emitted should include both col_a and col_new
+        last_schema = schema_calls[-1][0][1]  # positional arg: schema dict
+        self.assertIn("col_a", last_schema["properties"])
+        self.assertIn("col_new", last_schema["properties"])
+
+    def test_new_column_included_in_output_record(self, mock_stream_report, mock_singer):
+        """The new column's value must appear in the emitted record."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "col_a": {"type": ["string", "null"]},
+            }
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([
+            {"col_a": "v1", "col_new": "surprise"},
+        ])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        # RecordMessage is called with (tap_stream_id, record_dict, version=...)
+        rm_calls = mock_singer.RecordMessage.call_args_list
+        self.assertEqual(len(rm_calls), 1)
+        record = rm_calls[0][0][1]  # second positional arg = record dict
+        self.assertEqual(record["col_new"], "surprise")
+
+    # -----------------------------------------------------------------------
+    # AC-2: Columns with all-null values are included in output
+    # -----------------------------------------------------------------------
+
+    def test_missing_schema_columns_filled_with_null(self, mock_stream_report, mock_singer):
+        """If a record is missing a column defined in the schema, the output
+        record should have that column set to None."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "col_a": {"type": ["string", "null"]},
+                "col_b": {"type": ["string", "null"]},
+                "col_c": {"type": ["number", "null"]},
+            }
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([
+            {"col_a": "only_a"},  # col_b and col_c are missing
+        ])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        rm_calls = mock_singer.RecordMessage.call_args_list
+        self.assertEqual(len(rm_calls), 1)
+        record = rm_calls[0][0][1]  # second positional arg = record dict
+        self.assertIn("col_b", record)
+        self.assertIsNone(record["col_b"])
+        self.assertIn("col_c", record)
+        self.assertIsNone(record["col_c"])
+
+    # -----------------------------------------------------------------------
+    # Schema is NOT re-emitted when no new columns appear
+    # -----------------------------------------------------------------------
+
+    def test_no_schema_re_emit_when_no_new_columns(self, mock_stream_report, mock_singer):
+        """write_schema should not be called during sync if all record
+        columns are already in the schema."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "col_a": {"type": ["string", "null"]},
+                "col_b": {"type": ["number", "null"]},
+            }
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([
+            {"col_a": "v1", "col_b": 42},
+        ])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        mock_singer.write_schema.assert_not_called()
+
+    # -----------------------------------------------------------------------
+    # Multiple records – new column appears mid-stream
+    # -----------------------------------------------------------------------
+
+    def test_new_column_mid_stream(self, mock_stream_report, mock_singer):
+        """A new column appearing in the second record triggers a schema
+        re-emit. Already-emitted records cannot be backfilled."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "col_a": {"type": ["string", "null"]},
+            }
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([
+            {"col_a": "v1"},
+            {"col_a": "v2", "col_late": "appeared"},
+        ])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        # write_schema should have been called once (when col_late first appeared)
+        self.assertEqual(mock_singer.write_schema.call_count, 1)
+
+        # Both records should be written
+        rm_calls = mock_singer.RecordMessage.call_args_list
+        self.assertEqual(len(rm_calls), 2)
+
+        # First record: col_a should be there
+        first_record = rm_calls[0][0][1]
+        self.assertIn("col_a", first_record)
+
+        # Second record: col_late should have its value, col_a present too
+        second_record = rm_calls[1][0][1]
+        self.assertEqual(second_record["col_late"], "appeared")
+        self.assertIn("col_a", second_record)
+
+    # -----------------------------------------------------------------------
+    # Multiple new columns at once
+    # -----------------------------------------------------------------------
+
+    def test_multiple_new_columns_in_one_record(self, mock_stream_report, mock_singer):
+        """Multiple new columns in a single record are all captured."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "col_a": {"type": ["string", "null"]},
+            }
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([
+            {"col_a": "v1", "new1": "x", "new2": 99, "new3": True},
+        ])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        rm_calls = mock_singer.RecordMessage.call_args_list
+        record = rm_calls[0][0][1]
+        self.assertEqual(record["new1"], "x")
+        self.assertEqual(record["new2"], 99)
+        # bool True should pass through
+        self.assertIn("new3", record)
+
+    # -----------------------------------------------------------------------
+    # Return value = record count
+    # -----------------------------------------------------------------------
+
+    def test_returns_record_count(self, mock_stream_report, mock_singer):
+        """sync_report should return the total number of records processed."""
+        schema = {
+            "type": "object",
+            "properties": {"col_a": {"type": ["string", "null"]}}
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([
+            {"col_a": "v1"},
+            {"col_a": "v2"},
+            {"col_a": "v3"},
+        ])
+
+        count = sync_report(self._default_report(), stream, self._default_config())
+        self.assertEqual(count, 3)
+
+    # -----------------------------------------------------------------------
+    # _sdc_extracted_at is always present
+    # -----------------------------------------------------------------------
+
+    def test_sdc_extracted_at_present(self, mock_stream_report, mock_singer):
+        """Every output record should include _sdc_extracted_at."""
+        schema = {
+            "type": "object",
+            "properties": {"col_a": {"type": ["string", "null"]}}
+        }
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([{"col_a": "v1"}])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        rm_calls = mock_singer.RecordMessage.call_args_list
+        record = rm_calls[0][0][1]
+        self.assertIn("_sdc_extracted_at", record)
+
+    # -----------------------------------------------------------------------
+    # Inferred type for new columns is correct
+    # -----------------------------------------------------------------------
+
+    def test_inferred_type_for_new_string_column(self, mock_stream_report, mock_singer):
+        """A new string column should be inferred as nullable string."""
+        schema = {"type": "object", "properties": {}}
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([{"new_str": "hello"}])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        schema_call = mock_singer.write_schema.call_args_list[-1]
+        emitted_schema = schema_call[0][1]
+        self.assertEqual(
+            emitted_schema["properties"]["new_str"],
+            {"type": ["string", "null"]}
+        )
+
+    def test_inferred_type_for_new_numeric_column(self, mock_stream_report, mock_singer):
+        """A new numeric column should be inferred as nullable number."""
+        schema = {"type": "object", "properties": {}}
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([{"new_num": 42}])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        schema_call = mock_singer.write_schema.call_args_list[-1]
+        emitted_schema = schema_call[0][1]
+        self.assertEqual(
+            emitted_schema["properties"]["new_num"],
+            {"type": ["number", "null"]}
+        )
+
+    def test_inferred_type_for_new_none_column(self, mock_stream_report, mock_singer):
+        """A new column whose first value is None should default to nullable string."""
+        schema = {"type": "object", "properties": {}}
+        stream = _make_stream("test", schema)
+        mock_stream_report.return_value = iter([{"new_null": None}])
+
+        sync_report(self._default_report(), stream, self._default_config())
+
+        schema_call = mock_singer.write_schema.call_args_list[-1]
+        emitted_schema = schema_call[0][1]
+        self.assertEqual(
+            emitted_schema["properties"]["new_null"],
+            {"type": ["string", "null"]}
+        )

--- a/tests/unittests/test_zero_row_handling.py
+++ b/tests/unittests/test_zero_row_handling.py
@@ -1,0 +1,539 @@
+"""
+Unit tests for zero-row report handling.
+
+When a Workday report returns zero rows (e.g. a "yesterday's data" incremental
+report on a day with no changes), the connector must:
+
+    1. Complete successfully – no error raised.
+    2. Preserve the target table schema (write_schema still emitted).
+    3. Log "0 rows processed" clearly, not an error message.
+
+All API calls are mocked – no real credentials needed.
+"""
+
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tap_workday_raas import discover
+from tap_workday_raas.client import stream_report
+from tap_workday_raas.sync import sync_report
+
+
+# ---------------------------------------------------------------------------
+# XSD fixtures
+# ---------------------------------------------------------------------------
+
+XSD_FLAT = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:wd="urn:com.workday.report/Daily_Updates"
+            elementFormDefault="qualified" attributeFormDefault="qualified"
+            targetNamespace="urn:com.workday.report/Daily_Updates">
+    <xsd:element name="Report_Data" type="wd:Report_DataType"/>
+    <xsd:complexType name="Report_EntryType">
+        <xsd:sequence>
+            <xsd:element name="Employee_ID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Change_Date" type="xsd:date"   minOccurs="0"/>
+            <xsd:element name="Description" type="xsd:string" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Report_DataType">
+        <xsd:sequence>
+            <xsd:element name="Report_Entry" type="wd:Report_EntryType"
+                         minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>
+"""
+
+XSD_WITH_SUBGROUP = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:wd="urn:com.workday.report/Comp_Report"
+            elementFormDefault="qualified" attributeFormDefault="qualified"
+            targetNamespace="urn:com.workday.report/Comp_Report">
+    <xsd:element name="Report_Data" type="wd:Report_DataType"/>
+    <xsd:complexType name="Comp_groupType">
+        <xsd:sequence>
+            <xsd:element name="Pay_Rate" type="xsd:decimal" minOccurs="0"/>
+            <xsd:element name="Currency" type="xsd:string"  minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Report_EntryType">
+        <xsd:sequence>
+            <xsd:element name="Employee_ID" type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Name"        type="xsd:string" minOccurs="0"/>
+            <xsd:element name="Comp_group"  type="wd:Comp_groupType"
+                         minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="Report_DataType">
+        <xsd:sequence>
+            <xsd:element name="Report_Entry" type="wd:Report_EntryType"
+                         minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_stream(tap_stream_id, schema, metadata_list=None):
+    """Build a mock Singer CatalogEntry."""
+    stream = MagicMock()
+    stream.tap_stream_id = tap_stream_id
+    schema_obj = MagicMock()
+    schema_obj.to_dict.return_value = schema
+    stream.schema = schema_obj
+    if metadata_list is None:
+        metadata_list = [{"breadcrumb": [], "metadata": {}}]
+    stream.metadata = metadata_list
+    return stream
+
+
+# ===================================================================
+# AC-1: stream_report (client) – zero rows must NOT raise
+# ===================================================================
+
+class TestStreamReportZeroRows(unittest.TestCase):
+    """Verify that stream_report completes without error when the
+    Workday API returns a JSON response with no Report_Entry key
+    (the standard zero-row response is a JSON object without that key)."""
+
+    @patch("tap_workday_raas.client.requests.get")
+    def test_empty_json_object_no_report_entry_key(self, mock_get):
+        """Workday returns an empty JSON object → 0 records, no exception."""
+        body = json.dumps({}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.iter_content.return_value = [body]
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        records = list(stream_report("http://fake?format=json", "u", "p"))
+        self.assertEqual(records, [])
+
+    @patch("tap_workday_raas.client.requests.get")
+    def test_report_entry_present_but_empty_array(self, mock_get):
+        """Workday returns {"Report_Entry": []} → 0 records."""
+        body = json.dumps({"Report_Entry": []}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.iter_content.return_value = [body]
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        records = list(stream_report("http://fake", "u", "p"))
+        self.assertEqual(records, [])
+
+    @patch("tap_workday_raas.client.requests.get")
+    def test_report_entry_key_present_sets_found_key(self, mock_get):
+        """When the response contains Report_Entry, the found_key check
+        passes (no warning logged). We verify by checking that the warning
+        about missing Report_Entry is NOT emitted."""
+        body = json.dumps({
+            "Report_Entry": [
+                {"Employee_ID": "E001", "Name": "Alice"},
+            ]
+        }).encode("utf-8")
+        mock_resp = MagicMock()
+        # Use a single chunk large enough for the key detection
+        mock_resp.iter_content.return_value = [body]
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        with patch("tap_workday_raas.client.LOGGER") as mock_logger:
+            # Consume the generator fully
+            list(stream_report("http://fake", "u", "p"))
+            # The warning about missing Report_Entry should NOT fire
+            mock_logger.warning.assert_not_called()
+
+    @patch("tap_workday_raas.client.LOGGER")
+    @patch("tap_workday_raas.client.requests.get")
+    def test_empty_report_logs_warning(self, mock_get, mock_logger):
+        """When Report_Entry is missing, a warning is logged (not an error)."""
+        body = json.dumps({}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.iter_content.return_value = [body]
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        list(stream_report("http://fake", "u", "p"))
+
+        # Should have called LOGGER.warning, not raised
+        mock_logger.warning.assert_called_once()
+        # The warning uses %-style formatting: first positional is the template,
+        # second is the key name passed via %s
+        call_args = mock_logger.warning.call_args
+        full_message = call_args[0][0] % call_args[0][1:]
+        self.assertIn("Report_Entry", full_message)
+        self.assertIn("0 rows", full_message)
+
+    @patch("tap_workday_raas.client.requests.get")
+    def test_non_json_object_response_raises_exception(self, mock_get):
+        """When the response is not a valid JSON object (e.g. a bare
+        string or array), an exception should be raised."""
+        body = b'"not a json object"'
+        mock_resp = MagicMock()
+        mock_resp.iter_content.return_value = [body]
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        with self.assertRaises(Exception) as ctx:
+            list(stream_report("http://fake", "u", "p"))
+        self.assertIn("Report_Entry", str(ctx.exception))
+
+    @patch("tap_workday_raas.client.requests.get")
+    def test_json_object_without_report_entry_warns_not_raises(self, mock_get):
+        """When the response is a valid JSON object but has different keys
+        (no Report_Entry), treat as zero-row — warn, do not raise."""
+        body = json.dumps({"Some_Other_Key": "value"}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.iter_content.return_value = [body]
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        # Should NOT raise — valid JSON object, just no Report_Entry
+        records = list(stream_report("http://fake", "u", "p"))
+        self.assertEqual(records, [])
+
+    @patch("tap_workday_raas.client.requests.get")
+    def test_report_entry_key_split_across_chunks(self, mock_get):
+        """When the Report_Entry key is split across chunk boundaries,
+        the parser-based key detection should still find it (no false
+        'missing key' warning).  The old raw-byte-scan approach would
+        have missed the key when it straddled two chunks."""
+        body = json.dumps({
+            "Report_Entry": [
+                {"Employee_ID": "E001"}
+            ]
+        }).encode("utf-8")
+        # Split the body so that "Report_Entry" is spread across two
+        # chunks – the first chunk ends in the middle of the key.
+        key_pos = body.index(b"Report_Entry")
+        split_point = key_pos + 5  # mid-key: "Repor" | "t_Entry..."
+        chunks = [body[:split_point], body[split_point:]]
+
+        # Verify the key IS actually split (sanity check for the test)
+        self.assertNotIn(b"Report_Entry", chunks[0])
+        self.assertNotIn(b"Report_Entry", chunks[1])
+
+        mock_resp = MagicMock()
+        mock_resp.iter_content.return_value = chunks
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_get.return_value = mock_resp
+
+        with patch("tap_workday_raas.client.LOGGER") as mock_logger:
+            # Consume the generator – the key detection must succeed
+            list(stream_report("http://fake", "u", "p"))
+            # Parser-based detection should find the key despite the split;
+            # no "missing key" warning should be emitted.
+            mock_logger.warning.assert_not_called()
+
+
+# ===================================================================
+# AC-1 & AC-2: sync_report – zero rows completes successfully and
+#              schema is still emitted by the caller (do_sync)
+# ===================================================================
+
+@patch("tap_workday_raas.sync.singer")
+@patch("tap_workday_raas.sync.stream_report")
+class TestSyncReportZeroRows(unittest.TestCase):
+    """Verify sync_report returns 0, emits no records, and does not raise
+    when the API yields no rows."""
+
+    def _config(self):
+        return {"username": "u", "password": "p"}
+
+    def _report(self):
+        return {"report_url": "http://fake", "report_name": "daily_updates"}
+
+    def test_zero_rows_returns_zero(self, mock_stream_report, mock_singer):
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("daily_updates", schema)
+        mock_stream_report.return_value = iter([])
+
+        count = sync_report(self._report(), stream, self._config())
+
+        self.assertEqual(count, 0)
+
+    def test_zero_rows_no_record_messages(self, mock_stream_report, mock_singer):
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("daily_updates", schema)
+        mock_stream_report.return_value = iter([])
+
+        sync_report(self._report(), stream, self._config())
+
+        mock_singer.RecordMessage.assert_not_called()
+
+    def test_zero_rows_write_version_still_called(self, mock_stream_report, mock_singer):
+        """write_version should still be called so the target knows the
+        sync completed (even with 0 rows)."""
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("daily_updates", schema)
+        mock_stream_report.return_value = iter([])
+
+        sync_report(self._report(), stream, self._config())
+
+        mock_singer.write_version.assert_called_once()
+
+    def test_zero_rows_no_exception(self, mock_stream_report, mock_singer):
+        """Explicitly verify that no exception propagates."""
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("daily_updates", schema)
+        mock_stream_report.return_value = iter([])
+
+        try:
+            sync_report(self._report(), stream, self._config())
+        except Exception as exc:
+            self.fail("sync_report raised an exception on zero rows: {}".format(exc))
+
+    def test_zero_rows_with_subgroup_schema(self, mock_stream_report, mock_singer):
+        """Zero rows on a report that has sub-groups – still no error."""
+        schema = discover.generate_schema_for_report(XSD_WITH_SUBGROUP)
+        stream = _make_stream("comp_report", schema)
+        mock_stream_report.return_value = iter([])
+
+        count = sync_report(self._report(), stream, self._config())
+
+        self.assertEqual(count, 0)
+        mock_singer.RecordMessage.assert_not_called()
+
+
+# ===================================================================
+# AC-2: Target table schema preserved when 0 rows returned
+# ===================================================================
+
+class TestSchemaPreservedOnZeroRows(unittest.TestCase):
+    """The do_sync function writes the schema BEFORE calling sync_report.
+    Verify that the schema is emitted even when the report has 0 rows,
+    so the target table structure is preserved."""
+
+    @patch("tap_workday_raas.sync.stream_report")
+    @patch("tap_workday_raas.singer")
+    def test_do_sync_writes_schema_before_sync(self, mock_singer, mock_stream_report):
+        """Simulate do_sync flow: write_schema is called for the stream
+        regardless of sync_report returning 0 rows."""
+        from tap_workday_raas import do_sync
+
+        mock_stream_report.return_value = iter([])
+
+        schema_dict = discover.generate_schema_for_report(XSD_FLAT)
+
+        # Build a mock catalog
+        stream_obj = MagicMock()
+        stream_obj.tap_stream_id = "daily_updates"
+        stream_obj.schema = MagicMock()
+        stream_obj.schema.to_dict.return_value = schema_dict
+        stream_obj.metadata = [{"breadcrumb": [], "metadata": {}}]
+
+        catalog = MagicMock()
+        catalog.get_selected_streams.return_value = [stream_obj]
+
+        config = {
+            "username": "u",
+            "password": "p",
+            "reports": json.dumps([{
+                "report_url": "http://fake",
+                "report_name": "daily_updates",
+            }]),
+        }
+
+        do_sync(config, catalog, {})
+
+        # write_schema must have been called with our schema
+        schema_calls = [
+            c for c in mock_singer.write_schema.call_args_list
+        ]
+        self.assertGreaterEqual(len(schema_calls), 1,
+                                "write_schema should be called even for 0 rows")
+        emitted_schema = schema_calls[0][0][1]  # 2nd positional arg
+        self.assertEqual(set(emitted_schema["properties"].keys()),
+                         {"Employee_ID", "Change_Date", "Description"})
+
+    @patch("tap_workday_raas.discover.enrich_schema_from_data")
+    @patch("tap_workday_raas.discover.download_xsd")
+    def test_discover_schema_unchanged_by_empty_data(self, mock_xsd, mock_enrich):
+        """Discovery produces the full schema even when the data-enrichment
+        step sees zero records (the XSD alone defines the structure)."""
+        mock_xsd.return_value = XSD_WITH_SUBGROUP
+        mock_enrich.side_effect = lambda s, *a, **kw: s
+
+        streams = discover.discover_streams({
+            "username": "u", "password": "p",
+            "reports": '[{"report_url": "http://fake", "report_name": "rpt"}]',
+        })
+
+        schema = streams[0]["schema"]
+        # All columns from XSD must be present
+        self.assertIn("Employee_ID", schema["properties"])
+        self.assertIn("Name", schema["properties"])
+        self.assertIn("Comp_group", schema["properties"])
+
+
+# ===================================================================
+# AC-3: Logs clearly indicate "0 rows processed"
+# ===================================================================
+
+@patch("tap_workday_raas.sync.singer")
+@patch("tap_workday_raas.sync.stream_report")
+class TestZeroRowLogging(unittest.TestCase):
+    """Verify that zero-row syncs produce clear "0 rows" log messages
+    rather than error-level output."""
+
+    def _config(self):
+        return {"username": "u", "password": "p"}
+
+    def _report(self):
+        return {"report_url": "http://fake", "report_name": "daily_updates"}
+
+    @patch("tap_workday_raas.sync.LOGGER")
+    def test_sync_report_logs_zero_rows_info(self, mock_logger,
+                                              mock_stream_report, mock_singer):
+        """sync_report should log an INFO message about 0 rows."""
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("daily_updates", schema)
+        mock_stream_report.return_value = iter([])
+
+        sync_report(self._report(), stream, self._config())
+
+        # Find the zero-row info log
+        info_calls = mock_logger.info.call_args_list
+        zero_row_msgs = [
+            c for c in info_calls
+            if "0 rows" in str(c) or "0 row" in str(c)
+        ]
+        self.assertGreaterEqual(len(zero_row_msgs), 1,
+                                "Expected an INFO log about 0 rows, got: {}".format(
+                                    info_calls))
+
+    @patch("tap_workday_raas.sync.LOGGER")
+    def test_sync_report_does_not_log_error_on_zero_rows(self, mock_logger,
+                                                          mock_stream_report,
+                                                          mock_singer):
+        """No ERROR or CRITICAL log should be emitted for zero rows."""
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("daily_updates", schema)
+        mock_stream_report.return_value = iter([])
+
+        sync_report(self._report(), stream, self._config())
+
+        mock_logger.error.assert_not_called()
+        mock_logger.critical.assert_not_called()
+
+    @patch("tap_workday_raas.sync.LOGGER")
+    def test_nonzero_rows_does_not_log_zero_message(self, mock_logger,
+                                                     mock_stream_report,
+                                                     mock_singer):
+        """When rows ARE present, the zero-row message should NOT appear."""
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("daily_updates", schema)
+        mock_stream_report.return_value = iter([
+            {"Employee_ID": "E1", "Change_Date": "2024-01-01",
+             "Description": "Update"},
+        ])
+
+        sync_report(self._report(), stream, self._config())
+
+        info_calls = mock_logger.info.call_args_list
+        zero_row_msgs = [
+            c for c in info_calls
+            if "0 rows" in str(c)
+        ]
+        self.assertEqual(len(zero_row_msgs), 0,
+                         "Zero-row log should not appear when rows exist")
+
+
+# ===================================================================
+# End-to-end: XSD → discover → sync with zero rows
+# ===================================================================
+
+@patch("tap_workday_raas.sync.singer")
+@patch("tap_workday_raas.sync.stream_report")
+class TestEndToEndZeroRows(unittest.TestCase):
+    """Full pipeline tests: discover schema from XSD, then sync with an
+    empty result set — mimics the customer's incremental scenario on a
+    day with no updates."""
+
+    def _config(self):
+        return {"username": "u", "password": "p"}
+
+    def _report(self):
+        return {"report_url": "http://fake", "report_name": "rpt"}
+
+    def test_flat_report_zero_rows_end_to_end(self, mock_stream_report, mock_singer):
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+        stream = _make_stream("rpt", schema)
+        mock_stream_report.return_value = iter([])
+
+        count = sync_report(self._report(), stream, self._config())
+
+        self.assertEqual(count, 0)
+        mock_singer.write_version.assert_called_once()
+        mock_singer.RecordMessage.assert_not_called()
+
+    def test_subgroup_report_zero_rows_end_to_end(self, mock_stream_report, mock_singer):
+        schema = discover.generate_schema_for_report(XSD_WITH_SUBGROUP)
+        stream = _make_stream("rpt", schema)
+        mock_stream_report.return_value = iter([])
+
+        count = sync_report(self._report(), stream, self._config())
+
+        self.assertEqual(count, 0)
+        mock_singer.write_version.assert_called_once()
+        mock_singer.RecordMessage.assert_not_called()
+
+    def test_zero_then_nonzero_rows_sequential(self, mock_stream_report, mock_singer):
+        """Simulate two sequential syncs: first returns 0 rows, second
+        returns data. Both must succeed."""
+        schema = discover.generate_schema_for_report(XSD_FLAT)
+
+        # First sync – zero rows
+        stream1 = _make_stream("rpt", schema)
+        mock_stream_report.return_value = iter([])
+        count1 = sync_report(self._report(), stream1, self._config())
+        self.assertEqual(count1, 0)
+
+        # Reset mocks
+        mock_singer.reset_mock()
+        mock_stream_report.reset_mock()
+
+        # Second sync – has rows
+        stream2 = _make_stream("rpt", schema)
+        mock_stream_report.return_value = iter([
+            {"Employee_ID": "E1", "Change_Date": "2024-06-01",
+             "Description": "Promotion"},
+        ])
+        count2 = sync_report(self._report(), stream2, self._config())
+        self.assertEqual(count2, 1)
+        self.assertEqual(len(mock_singer.RecordMessage.call_args_list), 1)
+
+    def test_schema_columns_match_xsd_on_zero_rows(self, mock_stream_report, mock_singer):
+        """Even with 0 rows, the schema used by sync_report should still
+        contain all columns from the XSD."""
+        schema = discover.generate_schema_for_report(XSD_WITH_SUBGROUP)
+        stream = _make_stream("rpt", schema)
+        mock_stream_report.return_value = iter([])
+
+        sync_report(self._report(), stream, self._config())
+
+        # The schema that was built should have all columns from XSD
+        self.assertIn("Employee_ID", schema["properties"])
+        self.assertIn("Name", schema["properties"])
+        self.assertIn("Comp_group", schema["properties"])


### PR DESCRIPTION
# Description of change
- Fixed bugs related to Null only columns in metadata. 
- Check access of report url
- Validation for duplicate report name


# Manual QA steps
- [x]  Discovery: running
- [x]  Sync: running
- [x]  Unit Tests: running
- [ ]  Integration test: not running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
